### PR TITLE
Fix price input parsing issue caused by chat formatting

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,18 @@
 
 
-# ShopkeepersAddon - Economy & GUI Navigation Shopkeepers
+# ShopkeepersAddon (Fork) – Improved Price Input Handling
+
+**✅ This fork fixes a critical issue with price editing in the original ShopkeepersAddon.**  
+In the official version, entering a price in chat often results in the message “Invalid Price!” because many servers use chat plugins (e.g. ChatColor2, TAB, LPC, FreedomChat) that inject formatting or color codes into messages.  
+
+This fork updates the price parsing logic to:  
+- Remove color codes and formatting from chat inputs  
+- Accept both `10`, `10.00`, and `10,00` formats  
+- Support US and EU number styles  
+- Prevent `NumberFormatException` crashes  
+- Properly unregister the listener on the main thread  
+
+**Only the `SetPriceTask` class was modified! The rest of the plugin remains unchanged.**  
 
 ![banner](https://cdn.modrinth.com/data/cached_images/790af409b42cc8c9cd15b8d933a1dc2addf9ffd8.png)
 ## 🚀 **Transform Your Server's Economy!**

--- a/src/main/java/me/w41k3r/shopkeepersAddon/economy/objects/SetPriceTask.java
+++ b/src/main/java/me/w41k3r/shopkeepersAddon/economy/objects/SetPriceTask.java
@@ -7,6 +7,10 @@ import org.bukkit.event.HandlerList;
 import org.bukkit.event.Listener;
 import org.bukkit.event.player.AsyncPlayerChatEvent;
 
+import java.text.NumberFormat;
+import java.text.ParsePosition;
+import java.util.Locale;
+
 import static me.w41k3r.shopkeepersAddon.ShopkeepersAddon.*;
 
 public class SetPriceTask implements Listener {
@@ -30,28 +34,72 @@ public class SetPriceTask implements Listener {
             return;
         }
 
-        try {
-            if (event.getMessage().equalsIgnoreCase("cancel")) {
-                sendPlayerMessage(player, config.getString("messages.priceChangeCancelled"));
-                event.setCancelled(true);
-                HandlerList.unregisterAll(this);
-                return;
-            }
-            double price = Double.parseDouble(event.getMessage());
+        String message = event.getMessage().trim();
 
+        // cancel keyword
+        if (message.equalsIgnoreCase("cancel")) {
             event.setCancelled(true);
-
             Bukkit.getScheduler().runTask(plugin, () -> {
-                callback.onPriceSet(price, slot);
+                sendPlayerMessage(player, config.getString("messages.priceChangeCancelled"));
                 HandlerList.unregisterAll(this);
             });
+            return;
+        }
 
-            HandlerList.unregisterAll(this);
-
+        double price;
+        try {
+            price = parsePrice(message);
         } catch (NumberFormatException e) {
             event.setCancelled(true);
             sendPlayerMessage(player, config.getString("messages.invalidPrice"));
+            return;
         }
 
+        final double finalPrice = price;
+        event.setCancelled(true);
+        Bukkit.getScheduler().runTask(plugin, () -> {
+            callback.onPriceSet(finalPrice, slot);
+            HandlerList.unregisterAll(this);
+        });
+    }
+
+    /**
+     * Parse a user input price robustly:
+     * - strips non numeric / separator characters,
+     * - tries dot-normalized parse,
+     * - then tries NumberFormat for common locales (US, FR).
+     */
+    private double parsePrice(String input) throws NumberFormatException {
+        if (input == null) throw new NumberFormatException("null input");
+
+        String orig = input.trim();
+
+        // Keep only digits, comma, dot and minus sign (removes € $ letters § color codes, spaces, etc.)
+        String sanitized = orig.replaceAll("[^0-9,\\.-]", "");
+
+        if (sanitized.isEmpty()) throw new NumberFormatException("empty after sanitize");
+
+        // 1) quick try: replace comma with dot (accept "10", "10.00", "10,00")
+        try {
+            return Double.parseDouble(sanitized.replace(',', '.'));
+        } catch (NumberFormatException ignored) {
+        }
+
+        // 2) try parsing with NumberFormat for common locales and ensure full consumption
+        NumberFormat[] formats = new NumberFormat[]{
+                NumberFormat.getInstance(Locale.US),     // 1,234.56
+                NumberFormat.getInstance(Locale.FRANCE)  // 1.234,56
+        };
+
+        for (NumberFormat nf : formats) {
+            ParsePosition pos = new ParsePosition(0);
+            Number num = nf.parse(sanitized, pos);
+            if (num != null && pos.getIndex() == sanitized.length()) {
+                return num.doubleValue();
+            }
+        }
+
+        // nothing matched
+        throw new NumberFormatException("Invalid number: " + input);
     }
 }


### PR DESCRIPTION
Hello,
**This pull request fixes an issue where players could not set a price using chat input.**  
The problem occurred because chat formatting plugins were modifying the message before it was parsed, causing Double.parseDouble() to throw a NumberFormatException.
(Also makes sure to not Add the README.md i edited it was for me)

**✅ Changes:**
- Sanitize player chat input before parsing (removes formatting/color codes).
- Ensure valid numbers like "10", "10.00" or "10,00" are correctly detected.
- Prevent false "Invalid price" errors caused by chat plugins.

This update makes the price editing feature fully compatible with chat formatting plugins (e.g., ChatColor, LPC, DeluxeChat, etc.).

📹 A video demo is attached below showing the fix working with a formatted chat environment.

https://github.com/user-attachments/assets/67d673bb-5a9a-45ca-8363-c1fe15959329